### PR TITLE
Custom message/code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ Specific action permissions take precedence over general read or write permissio
 
 The ``partial_update`` action is also supported, but by default is grouped with the update permission.
 
+## Custom message and status code for rejected permissions
+DRY Rest Permissions allows you to define a custom message and status code for rejected permissions. This is useful for returning some information to the client app about why a request was rejected.
+
+To produce a custom message and/or status code, permissions functions can return a dict with the keys ``message`` and ``code`` instead of a boolean. Returning a dict is interpreted as a rejection of the permission. Other complex return formats are allowed, but dicts are recommended.
+
 ## Add permissions to an API
 
 Permissions can be added to ModelViewSet based APIs.
@@ -195,6 +200,19 @@ class Project(models.Model):
     def has_object_publish_permission(self, request):
         return request.user == self.owner
 ``` 
+### Custom message and status code for rejected permissions
+If we wanted to add a little more detail to our permissions we could return a dict with a custom message and status code.
+```python
+class Project(models.Model):
+    owner = models.ForeignKey('User')
+    ...      
+    def has_object_write_permission(self, request):
+        if request.user == self.owner:
+            return True
+        return {'message': 'You must be the owner of this project to modify it.', 'code': 403}
+```
+We could also return a string (interpreted as the rejection message), an int (interpreted as the rejection status code), or a tuple of (message, code). Dicts are recommended for clarity. Both message and code keys are optional.
+
 ### Helpful decorators
 Three decorators were defined for common permission checks
 ``@allow_staff_or_superuser`` - Allows any user that has staff or superuser status to have the permission.


### PR DESCRIPTION
| Q                                               | R
| ----------------------------------------------- | -------------------------------------------
|  Type of contribution ? (fix, enhancement, ..)  | Enhancement
|  Tickets (_issues_) concerned               |  #27  

---

##### What have you changed ?
Added support for returning non-boolean values from permission methods.
- `dict` with 'message' (str) and 'code' (int) keys will allow you to provide a reason and custom HTTP status code in the response
- `str` will allow you to provide a reason in the response
- `int` will allow you to provide a custom HTTP status code in the response
- `tuple` (message, code) will allow you to provide a reason and custom HTTP status code in the response

##### How did you change it ? (architectural consideration)
Return values for `DRYPermissions.has_permission()` and `DRYPermissions.has_object_permission()` are now run through `DRYPermissions._process_permission_result()` where non-boolean values are scraped for message/code information. That information is used to update `self.message` and `self.code`, and boolean False is returned. 
This means that Django's generic `APIView.permission_denied()` method recieves the message and code for further processing.

##### Is there a special consideration?
None that I'm aware of - should integrate with Django's preferred approach.

Verification :
 - [x] The pull-request description is filled accordingly
 - [x] This Pull-Request fully meets the requirements defined in the issue
 - [x] All my commits name have max 50 chars
 - [x] I added or modified the attached tests
 - [x] I added or modified the documentation